### PR TITLE
Correr tests en firefox o chrome

### DIFF
--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -1,0 +1,41 @@
+name: Probar página
+
+on:
+  workflow_dispatch:
+    inputs:
+      browser:
+        description: 'Browser to run tests'
+        required: true
+        default: chrome
+        type: choice
+        options:
+        - firefox
+        - chrome
+
+env:
+  BROWSER: ${{ github.event.inputs.browser }}
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    services:
+      selenium:
+        image: selenium/standalone-${{ github.event.inputs.browser }}
+        options: --shm-size=2gb
+        ports:
+          - 4444:4444
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.10"
+      - run: pip install -r requirements.txt -r test-requirements.txt
+      - run: pytest
+      - uses: actions/upload-artifact@v3
+        if: always()
+        with:
+          name: screenshots
+          path: screenshots/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ Pipfile.lock
 *.pyc
 .vscode/
 geckodriver.log
+.env

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ luego ejecuta el validador w3c_validator usando los comandos:
 
 ### Selenium
 
-Para usar selenium se requiere tener ejecutandose un webdriver [instala el webdriver correspondiente a tu plataforma](https://selenium-python.readthedocs.io/installation.html#drivers)
+Para usar selenium se requiere tener ejecutándose un webdriver [instala el webdriver correspondiente a tu plataforma](https://selenium-python.readthedocs.io/installation.html#drivers)
 
 Usando [docker compose](https://docs.docker.com/compose/install/) nos podemos ahorrar algo del tiempo de configuración de los distintos servicios
 
@@ -155,3 +155,8 @@ para ejecutar los test ejecuta los siguientes comandos
 
     docker compose up
     pytest
+
+Por defecto los test corren en chrome, si deseas escoger el navegador que quieres ejecutar, crea una variable de entorno llamada BROWSER con el navegador que deseas usar, en estos momentos soportamos firefox y chrome.
+La forma mas fácil de hacer esto es creando un archivo  `.env` con el siguiente contenido
+
+    BROWSER=firefox

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,7 +1,7 @@
 version: '3'
 services:
-  chrome:
-    image: selenium/standalone-chrome
+  browser:
+    image: selenium/standalone-${BROWSER:-chrome}
     shm_size: '2gb'
     ports:
       - 4444:4444 # Selenium service

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -9,3 +9,5 @@ screenpy==4.1.2
 pyhamcrest==2.0.4
 screenpy-selenium==4.0.3
 Online-W3C-Validator==0.3.20
+py==1.11.0
+python_dotenv==1.0.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,13 +2,24 @@
 Configuración de test automatizados
 """
 
+import os
+import pytest
 from typing import Generator
 from selenium.webdriver import Remote
-from selenium.webdriver.chrome.options import Options
-import pytest
+from selenium.webdriver.chrome.options import Options as ChromeOptions
+from selenium.webdriver.firefox.options import Options as FirefoxOptions
+from dotenv import load_dotenv
+
+load_dotenv()
 
 @pytest.fixture(name="driver")
 def fixture_driver() -> Generator:
-    """Creamos el actor que vamos a usar en nuestros tests!"""
-    driver = Remote(command_executor='http://127.0.0.1:4444/wd/hub', options=Options())
+    """Creamos el webdriver que vamos a usar en nuestros tests!"""
+    posible_options = {
+        "chrome": ChromeOptions(),
+        "firefox": FirefoxOptions()
+    }
+    browser = os.getenv("BROWSER", "chrome")
+    options = posible_options[browser]
+    driver = Remote(command_executor="http://127.0.0.1:4444/wd/hub", options=options)
     yield driver


### PR DESCRIPTION
# Pull request

Closes #385 

## Observaciones

Ejecutado manualmente

Ejecución en chrome
gh workflow run test-e2e.yml --ref 385-tests-firefox-chrome

https://github.com/Scot3004/django-quilla-web/actions/runs/4591658514/jobs/8108010755

![image](https://user-images.githubusercontent.com/1175402/229387532-8c469320-6f4b-454f-82cf-b88aad18787a.png)

Ejecución en firefox

gh workflow run test-e2e.yml --ref 385-tests-firefox-chrome -F browser=firefox

https://github.com/Scot3004/django-quilla-web/actions/runs/4591651050/jobs/8107997065

![image](https://user-images.githubusercontent.com/1175402/229388058-360f47c7-ea33-48b1-ab6e-3a24ea3e2198.png)




