### PR TITLE
Render title refactor

### DIFF
--- a/templates/blocks/heading.html
+++ b/templates/blocks/heading.html
@@ -1,7 +1,2 @@
-<div class="heading-title">
-  <div class="container">
-    <div class="row">
-      <h2>{{ this.title }}</h2>
-    </div>
-  </div>
-</div>
+{% from "macros/title.html" import render_title %}
+{{render_title(this.title)}}

--- a/templates/blog-post.html
+++ b/templates/blog-post.html
@@ -1,6 +1,7 @@
 {% extends "layout.html" %}
 {% from "macros/blog.html" import render_blog_post, render_author %}
 {% from "macros/social.html" import render_social %}
+{% from "macros/title.html" import render_title %}
 {% block title %}{{ this.title }}{% endblock %}
 {% block page_seo %}
   <meta property="og:title" content="{{ this.title }}" />
@@ -13,13 +14,7 @@
   <meta property="og:description" content="{{ this.excerpt|striptags }}" />
 {% endblock %}
 {% block body %}
-<div class="heading-title">
-  <div class="container">
-  <div class="row">
-    <h1>{{bag('blog', alt, 'blog')}}</h1>
-  </div>
-  </div>
-</div>
+{{render_title(this.parent.title)}}
 {% for image in this.attachments %}
   <div class="d-flex justify-content-center">
     <p><img class="center-block img-fluid" src="{{ image|url }}" alt=""></p>

--- a/templates/blog-post.html
+++ b/templates/blog-post.html
@@ -1,7 +1,6 @@
 {% extends "layout.html" %}
 {% from "macros/blog.html" import render_blog_post, render_author %}
 {% from "macros/social.html" import render_social %}
-{% from "macros/title.html" import render_title %}
 {% block title %}{{ this.title }}{% endblock %}
 {% block page_seo %}
   <meta property="og:title" content="{{ this.title }}" />
@@ -14,7 +13,6 @@
   <meta property="og:description" content="{{ this.excerpt|striptags }}" />
 {% endblock %}
 {% block body %}
-{{render_title(this.parent.title)}}
 {% for image in this.attachments %}
   <div class="d-flex justify-content-center">
     <p><img class="center-block img-fluid" src="{{ image|url }}" alt=""></p>

--- a/templates/blog.html
+++ b/templates/blog.html
@@ -1,16 +1,11 @@
 {% extends "layout.html" %}
 {% from "macros/blog.html" import render_blog_post, render_author %}
 {% from "macros/pagination.html" import render_pagination %}
+{% from "macros/title.html" import render_title %}
 {% block title %}Blog{% endblock %}
 
 {% block body %}
-<div class="heading-title">
-  <div class="container">
-    <div class="row">
-      <h1>Blog</h1>
-    </div>
-  </div>
-</div>
+{{render_title(this.title)}}
 <div class="container">
     <div class="row blog_post-posts">
         {% for post in this.pagination.items %}

--- a/templates/nosotros-miembro.html
+++ b/templates/nosotros-miembro.html
@@ -1,15 +1,9 @@
+{% from "macros/title.html" import render_title %}
 {% extends "layout.html" %}
 {% set translated_role = bag('nosotros', this.alt, this.role) %}
 
 {% block body %}
-<div class="heading-title">
-  <div class="container">
-    <div class="row">
-      <h1>{{bag('nosotros', alt, 'nosotros')}}</h1>
-    </div>
-  </div>
-</div>
-
+{{render_title(this.parent.title)}}
 <div class="d-flex justify-content-center">
   <div class="nosotros-miembro">
     <div class="card mb-3">


### PR DESCRIPTION
# Pull request

Closes #413 

## Observaciones

Este pequeño refactor, lo que ayuda es a eliminar codigo html duplicado relacionado con ese bloque azul que aparece en casi todas las páginas, para ello se usa la macro render_title la cual recibe el titulo y renderiza el html

En un nuevo commit se adiciono la eliminación del heading title en los blog post
