### PR TITLE
Eventos 2022

### DIFF
--- a/content/eventos/2022-02-24-deteccion-de-cancer-pulmonar-usando-procesamiento-de-imagenes/contents.lr
+++ b/content/eventos/2022-02-24-deteccion-de-cancer-pulmonar-usando-procesamiento-de-imagenes/contents.lr
@@ -4,13 +4,23 @@ date_start: 2022-02-24 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/283752356/
 ---
-information: <p>El cáncer pulmonar es una enfermedad con altos índices de mortalidad de acuerdo a la OMS. Considerando las imágenes médicas es posible realizar un diagnóstico. Es posible realizar esta tarea usando Procesamiento de Imágenes y Machine Learning para detectar las zonas de interés.</p> <p>Ponente: candidato a PhD Josimar Chiré</p> <p>Científico de datos, con experiencia en diferentes áreas como Salud Pública, Minería, Energía, Deporte. Investigador en el área de Inteligencia Artificial. Fundador de Research4Tech, comunidad de investigadores latinos que fomentan el área de IA.</p> <p>-----<br/>Adicionales:</p> <p>Transmitiremos por el canal del YouTube de Python Colombia. Suscríbete y dale click a la campanita para estar pendiente de eventos en otras comunidades xD</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/b/9/0/b/600_501887371.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Detección de Cáncer Pulmonar usando Procesamiento de Imágenes
 ----
-attach: <a href="https://youtu.be/fAG3_nMPpjU">Video Youtube</a>
+details: El cáncer pulmonar es una enfermedad con altos índices de mortalidad de acuerdo a la OMS. Considerando las imágenes médicas es posible realizar un diagnóstico. Es posible realizar esta tarea usando Procesamiento de Imágenes y Machine Learning para detectar las zonas de interés.<
+----
+speaker: 
+----
+speaker_name: Josimar Chiré
+----
+speaker_bio: Científico de datos, con experiencia en diferentes áreas como Salud Pública, Minería, Energía, Deporte. Investigador en el área de Inteligencia Artificial. Fundador de Research4Tech, comunidad de investigadores latinos que fomentan el área de IA.
+----
+attach: 
+---
+youtube: fAG3_nMPpjU

--- a/content/eventos/2022-03-17-cross-modal-conectando-el-mundo-de-nlp-con-el-de-computer-vision/contents.lr
+++ b/content/eventos/2022-03-17-cross-modal-conectando-el-mundo-de-nlp-con-el-de-computer-vision/contents.lr
@@ -4,13 +4,29 @@ date_start: 2022-03-17 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/284362973/
 ---
-information: <p>Imagínate que ahora vas a poder buscar escenas de un video sin que el texto este relacionado con el titulo del video.<br/>¿Quieres buscar el momento cuando Messi le metió un gol al Bayern? La IA te puede reconocer la escena y dar el resultado.<br/>En esta charla veremos como una IA puede encontrar acciones dentro de un video a partir de un texto dado</p> <p>Ponente: Wayner Barrios</p> <p>Estudiante de PhD en Dartmouth College</p> <p>***</p> <p>Adicionales:</p> <p>Transmitiremos por el canal del YouTube de Python Colombia. Suscríbete y dale click a la campanita para estar pendiente de eventos en otras comunidades xD</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/9/7/4/a/600_502418730.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Cross Modal: Conectando el mundo de NLP con el de Computer Vision
 ----
-attach: <a href="https://youtu.be/hLOxurqMOkQ">Video Youtube</a>
+details:
+
+Imagínate que ahora vas a poder buscar escenas de un video sin que el texto este relacionado con el titulo del video.
+
+¿Quieres buscar el momento cuando Messi le metió un gol al Bayern? La IA te puede reconocer la escena y dar el resultado.
+
+En esta charla veremos como una IA puede encontrar acciones dentro de un video a partir de un texto dado
+----
+speaker: 
+----
+speaker_name: Wayner Barrios
+----
+speaker_bio: Estudiante de PhD en Dartmouth College
+----
+attach: 
+---
+youtube: hLOxurqMOkQ

--- a/content/eventos/2022-04-28-conversatorio-de-junior-a-senior-conmemorando-7-anos-de-comunidad/contents.lr
+++ b/content/eventos/2022-04-28-conversatorio-de-junior-a-senior-conmemorando-7-anos-de-comunidad/contents.lr
@@ -4,13 +4,61 @@ date_start: 2022-04-28 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/285381547/
 ---
-information: <p>En este conversatorio ameno estaremos hablando con varios de los primeros miembros que tuvo la comunidad y platicaremos como ha sido su evolución a lo largo de estos 7 años de comunidad.</p> <p>Ponente: Dario Guzman, Oswaldo Rodriguez, Leonardo Orozco y Sergio Orozco</p> <p>Miembros de la comunidad desde sus inicios en el 2015</p> <p>***</p> <p>Adicionales:</p> <p>Transmitiremos por el canal del YouTube de Python Colombia. Suscríbete y dale click a la campanita para estar pendiente de eventos en otras comunidades xD</p> 
+information:
+
+En este conversatorio ameno estaremos hablando con varios de los primeros miembros que tuvo la comunidad y platicaremos como ha sido su evolución a lo largo de estos 7 años de comunidad.</p> <p>Ponente: Dario Guzman, Oswaldo Rodriguez, Leonardo Orozco y Sergio Orozco</p> <p>Miembros de la comunidad desde sus inicios en el 2015</p> <p>***</p> <p>Adicionales:</p> <p>Transmitiremos por el canal del YouTube de Python Colombia. Suscríbete y dale click a la campanita para estar pendiente de eventos en otras comunidades xD</p> 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/5/3/b/0/600_503661424.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
-title: Conversatorio de junior a senior: Conmemorando 7 años de comunidad
+title: 
 ----
-attach: <a href="https://youtu.be/M5-witzXkDk">Video Youtube</a>
+details: 
+----
+speaker: dario-guzman
+----
+speaker_name: 
+----
+speaker_bio: 
+----
+attach: 
+#### talk ####
+title: 
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Oswaldo Rodriguez
+----
+speaker_bio: 
+----
+attach: 
+#### talk ####
+title: 
+----
+details: 
+----
+speaker: leonardo-orozco
+----
+speaker_name: 
+----
+speaker_bio: 
+----
+attach: 
+#### talk ####
+title: 
+----
+details: 
+----
+speaker: sergio-orozco
+----
+speaker_name: 
+----
+speaker_bio: 
+----
+attach: 
+---
+youtube: M5-witzXkDk

--- a/content/eventos/2022-05-26-sympy-como-herramienta-de-aprendizaje-en-matematicas-y-programacion/contents.lr
+++ b/content/eventos/2022-05-26-sympy-como-herramienta-de-aprendizaje-en-matematicas-y-programacion/contents.lr
@@ -4,13 +4,23 @@ date_start: 2022-05-26 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/285972551/
 ---
-information: <p>Nivel de la charla: Principiante</p> <p>La charla propuesta tiene como finalidad ofrecer una ayuda para los estudiantes de últimos años de bachillerato, primeros semestres de universidad o aspirantes a convertirse en científicos de datos, comprender la relación entre las matemáticas con la programación simbólica, por lo cual, el módulo SymPy de Python se convierte en un recurso para que ellos puedan aprender y comprender los conceptos básicos de programación mientras realizan diferentes cálculos matemáticos.</p> <p>Ponente: Alfonso Jiménez</p> <p>Soy ingeniero de sistemas de la Pontificia Universidad Javeriana, con más de 4 años de experiencia laboral. Soy desarrollador Web fullstack, certificado en la especialización Python for Everybody de Coursera y la Universidad de Michigan, estuve como mentor del Club de Chicas Programadoras durante el año 2021 y terminé con éxito el reto Datacademy de Platzi, actualmente estoy interesado en aplicaciones Web y para análisis de datos con Python, y apasionado por enseñar matemáticas, física y programación.</p> <p>***</p> <p>Adicionales:</p> <p>Transmitiremos por el canal del YouTube de Python Colombia. Suscríbete y dale click a la campanita para estar pendiente de eventos en otras comunidades xD</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/2/0/9/600_504180521.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: SymPy como herramienta de aprendizaje en matemáticas y programación
 ----
-attach: <a href="https://youtu.be/L7PsaOu0bSQ">Video Youtube</a> / <a href="https://docs.google.com/presentation/d/1-651PmUg0vtHeAPZdi5ieuokoVrLJ5x0/edit?usp=sharing&ouid=102956723374392876682&rtpof=true&sd=true">Diapositivas</a> / <a href="https://colab.research.google.com/drive/1iIknZcj1TEfKTEKGHvdTJCBBmNrsoIw6?usp=sharing">Google Colab</a>
+details: La charla propuesta tiene como finalidad ofrecer una ayuda para los estudiantes de últimos años de bachillerato, primeros semestres de universidad o aspirantes a convertirse en científicos de datos, comprender la relación entre las matemáticas con la programación simbólica, por lo cual, el módulo SymPy de Python se convierte en un recurso para que ellos puedan aprender y comprender los conceptos básicos de programación mientras realizan diferentes cálculos matemáticos.
+----
+speaker: 
+----
+speaker_name: Alfonso Jiménez
+----
+speaker_bio: Soy ingeniero de sistemas de la Pontificia Universidad Javeriana, con más de 4 años de experiencia laboral. Soy desarrollador Web fullstack, certificado en la especialización Python for Everybody de Coursera y la Universidad de Michigan, estuve como mentor del Club de Chicas Programadoras durante el año 2021 y terminé con éxito el reto Datacademy de Platzi, actualmente estoy interesado en aplicaciones Web y para análisis de datos con Python, y apasionado por enseñar matemáticas, física y programación.
+----
+attach: <a href="https://docs.google.com/presentation/d/1-651PmUg0vtHeAPZdi5ieuokoVrLJ5x0/edit?usp=sharing&ouid=102956723374392876682&rtpof=true&sd=true">Diapositivas</a> / <a href="https://colab.research.google.com/drive/1iIknZcj1TEfKTEKGHvdTJCBBmNrsoIw6?usp=sharing">Google Colab</a>
+---
+youtube: L7PsaOu0bSQ

--- a/content/eventos/2022-07-07-principios-solid-en-python/contents.lr
+++ b/content/eventos/2022-07-07-principios-solid-en-python/contents.lr
@@ -4,13 +4,25 @@ date_start: 2022-07-07 19:00
 ---
 link: https://www.meetup.com/pythonbaq/events/286559607/
 ---
-information: <p>Muchas veces cuando construimos software productivo pasamos por alto que nuestro código probablemente en el futuro necesitemos que se adapte a nuevos cambios o es muy común deba ser comprendido por algún integrante de nuestro equipo. Es aquí en donde los principios SOLID nos van a ayudar a escribir código más limpio, mantenible y escalable<br/>En esta charla los conoceremos y veremos como aplicarlos en Python para escribir programas de mayor calidad.</p> <p>Ponente: Emiliano Martin</p> <p>¡Hola! Mi nombre es Emiliano Martín, tengo 30 años y vivo en Córdoba, Argentina. Estudié Ingeniería en Sistemas de Información en la [UTN](<a href="https://www.frvm.utn.edu.ar/" class="linkified">https://www.frvm.utn.edu.ar/</a>) y actualmente trabajo en [Mercadolibre](<a href="https://www.mercadolibre.com.ar/" class="linkified">https://www.mercadolibre.com.ar/</a>) como Technical Leader.<br/>Me apasiona el desarrollo de software en general, me gusta estar en un constante aprendizaje de nuevas tecnologías y buenas prácticas de programación.Puedes encontrarme en [Github](<a href="https://github.com/emimartin26" class="linkified">https://github.com/emimartin26</a>), [Linkedin](<a href="https://www.linkedin.com/in/emimartin26/" class="linkified">https://www.linkedin.com/in/emimartin26/</a>) y [Twitter](<a href="https://twitter.com/emimartin26" class="linkified">https://twitter.com/emimartin26</a>) o si prefieres, puedes enviarme un [correo electrónico](mailto:[masked]).</p> <p>***</p> <p>Adicionales:</p> <p>Transmitiremos por el canal del YouTube de Python Colombia. Suscríbete y dale click a la campanita para estar pendiente de eventos en otras comunidades xD</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/2/4/3/0/600_505329264.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Principios SOLID en Python
 ----
-attach: <a href="https://youtu.be/ZjQyjDWyLCc">Video Youtube</a> / <a href="https://github.com/emimartin26/solid_python/tree/master/practices">Github</a>
+details: Muchas veces cuando construimos software productivo pasamos por alto que nuestro código probablemente en el futuro necesitemos que se adapte a nuevos cambios o es muy común deba ser comprendido por algún integrante de nuestro equipo. Es aquí en donde los principios SOLID nos van a ayudar a escribir código más limpio, mantenible y escalable<br/>En esta charla los conoceremos y veremos como aplicarlos en Python para escribir programas de mayor calidad.
+----
+speaker: 
+----
+speaker_name:
+
+ Emiliano Martin
+----
+speaker_bio: tengo 30 años y vivo en Córdoba, Argentina. Estudié Ingeniería en Sistemas de Información en la [UTN](<a href="https://www.frvm.utn.edu.ar/" class="linkified">https://www.frvm.utn.edu.ar/</a>) y actualmente trabajo en [Mercadolibre](<a href="https://www.mercadolibre.com.ar/" class="linkified">https://www.mercadolibre.com.ar/</a>) como Technical Leader.<br/>Me apasiona el desarrollo de software en general, me gusta estar en un constante aprendizaje de nuevas tecnologías y buenas prácticas de programación.Puedes encontrarme en [Github](<a href="https://github.com/emimartin26" class="linkified">https://github.com/emimartin26</a>), [Linkedin](<a href="https://www.linkedin.com/in/emimartin26/" class="linkified">https://www.linkedin.com/in/emimartin26/</a>) y [Twitter](<a href="https://twitter.com/emimartin26" class="linkified">https://twitter.com/emimartin26</a>)
+----
+attach: <a href="https://github.com/emimartin26/solid_python/tree/master/practices">Github</a>
+---
+youtube: ZjQyjDWyLCc

--- a/content/eventos/2022-07-28-automatizacion-de-ui-en-python-aplicando-el-patron-screenplay/contents.lr
+++ b/content/eventos/2022-07-28-automatizacion-de-ui-en-python-aplicando-el-patron-screenplay/contents.lr
@@ -4,13 +4,26 @@ date_start: 2022-07-28 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/287291051/
 ---
-information: <p>Vamos a tomar el sitio de Python Barranquilla y otra página de ejemplo adicional para aprender cómo podemos hacer automatizaciones de ui usando una alternativa al patrón pague object model, el patrón screenplay para desarrollar pruebas de ui fácilmente extensibles.<br/>Ponente: Sergio Orozco<br/>Co-organizador de Python Barranquilla. Trabaja en Perficient como QA automation engineer, lleva 9 años trabajando en desarrollo de software de los cuales los últimos 4 los ha dedicado al área de QA.</p> <p>***</p> <p>Adicionales:</p> <p>Transmitiremos por el canal del YouTube de Python Colombia. Suscríbete y dale click a la campanita para estar pendiente de eventos en otras comunidades xD</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/d/4/6/f/600_505674383.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Automatización de UI en Python aplicando el patrón Screenplay
 ----
-attach: <a href="https://youtu.be/s_h5uAZB8yU">Video Youtube</a> / <a href="https://github.com/Scot3004/web2021/blob/master/content/blog/2022-08-14-screenpy.mdx">Github</a>
+details: Vamos a tomar el sitio de Python Barranquilla y otra página de ejemplo adicional para aprender cómo podemos hacer automatizaciones de ui usando una alternativa al patrón pague object model, el patrón screenplay para desarrollar pruebas de ui fácilmente extensibles.
+----
+speaker: sergio-orozco
+----
+speaker_name: 
+----
+speaker_bio: Co-organizador de Python Barranquilla. Trabaja en Perficient como QA automation engineer, lleva 9 años trabajando en desarrollo de software de los cuales los últimos 4 los ha dedicado al área de QA.
+----
+attach:
+
+* [Blog post](https://secorto.com/blog/2022-08-14-screenpy)
+* [Gist](https://gist.github.com/Scot3004/56723aa4237961b5a250ffd17c53996f)
+---
+youtube: s_h5uAZB8yU

--- a/content/eventos/2022-08-25-fomentando-la-programacion-desde-la-infancia/contents.lr
+++ b/content/eventos/2022-08-25-fomentando-la-programacion-desde-la-infancia/contents.lr
@@ -4,13 +4,35 @@ date_start: 2022-08-25 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/287762297/
 ---
-information: <p>En este conversatorio hablaremos sobre aprender a como fomentar la pasión por la programacion a temprana edad desde la experiencia de nuestros invitados, quienes serán Jairo Coronado, decano del Departamento de Productividad e Innovación en Universidad de la Costa y Johann Echavarría, Software Architect/Tech Lead en Globant.<br/>Si quieres hacer parte de esta conversación y hacer preguntas en vivo a nuestros invitados, te esperamos el jueves 25 de agosto a las 7:30pm hora Colombia.</p> <p>***</p> <p>Adicionales:</p> <p>Transmitiremos por el canal del YouTube de Python Colombia. Suscríbete y dale click a la campanita para estar pendiente de eventos en otras comunidades xD</p> 
+information: En este conversatorio hablaremos sobre aprender a como fomentar la pasión por la programacion a temprana edad desde la experiencia de nuestros invitados
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/8/f/4/4/600_506436676.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
-title: Fomentando la programación desde la infancia
+title: 
 ----
-attach: <a href="https://youtu.be/RIx-Wf1dZ6U">Video Youtube</a>
+details: 
+----
+speaker: 
+----
+speaker_name: Jairo Coronado
+----
+speaker_bio: Decano del Departamento de Productividad e Innovación en Universidad de la Costa
+----
+attach: 
+#### talk ####
+title: 
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Johann Echavarría
+----
+speaker_bio: Software Architect/Tech Lead en Globant.
+----
+attach: 
+---
+youtube: RIx-Wf1dZ6U

--- a/content/eventos/2022-09-29-consiguiendo-trabajo-como-programador-a-los-45-anos/contents.lr
+++ b/content/eventos/2022-09-29-consiguiendo-trabajo-como-programador-a-los-45-anos/contents.lr
@@ -4,13 +4,23 @@ date_start: 2022-09-29 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/288355536/
 ---
-information: <p>¿Has pensado darle un giro a tu vida? ¿Estás en la mediana edad y tienes muchas preguntas sobre el futuro? ¿Es posible hacer un cambio radical? En esta charla conversaremos con una persona que hizo el cambio y nos contará sobre su experiencia.</p> <p>Ponente: Jorge Rueda</p> <p>Ingeniero de desarrollo backend en Genial.io, curioso por Linux, contenedores, Python y base de datos MongoDB, Ingeniero Electrónico Javeriano y amante del cine</p> <p>***</p> <p>Adicionales:</p> <p>Transmitiremos por el canal del YouTube de Python Colombia. Suscríbete y dale click a la campanita para estar pendiente de eventos en otras comunidades xD</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/1/c/7/9/600_507367289.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Consiguiendo trabajo como programador a los 45 años
 ----
-attach: <a href="https://youtu.be/kOSqcrgTlhI">Video Youtube</a> / <a href="https://drive.google.com/file/d/1vTU5p44bn4mrOBzt5q6araKo0Rx0wm5O/view?usp=sharing">Diapositivas</a>
+details: ¿Has pensado darle un giro a tu vida? ¿Estás en la mediana edad y tienes muchas preguntas sobre el futuro? ¿Es posible hacer un cambio radical? En esta charla conversaremos con una persona que hizo el cambio y nos contará sobre su experiencia.
+----
+speaker: jorge-rueda
+----
+speaker_name: 
+----
+speaker_bio: Ingeniero de desarrollo backend en Genial.io, curioso por Linux, contenedores, Python y base de datos MongoDB, Ingeniero Electrónico Javeriano y amante del cine
+----
+attach: <a href="https://drive.google.com/file/d/1vTU5p44bn4mrOBzt5q6araKo0Rx0wm5O/view?usp=sharing">Diapositivas</a>
+---
+youtube: kOSqcrgTlhI

--- a/content/eventos/2022-10-27-introduccion-al-pentesting/contents.lr
+++ b/content/eventos/2022-10-27-introduccion-al-pentesting/contents.lr
@@ -4,13 +4,23 @@ date_start: 2022-10-27 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/289190407/
 ---
-information: <p>En esta charla usaremos Python como herramienta para atacar sistemas usando la metodología del Pentesting.</p> <p>Ponente: Sergio Molinares</p> <p>Tecnologo en sistemas, apasionado de la seguridad informática, desarrollador Python en desarrollo, con muy buena experiencia en infraestructura, ccna cisco, We speake security, redteam, ctf player, investigador en el área de la seguridad</p> <p>***</p> <p>Adicionales:</p> <p>Transmitiremos por el canal del YouTube de Python Colombia. Suscríbete y dale click a la campanita para estar pendiente de eventos en otras comunidades xD</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/2/4/b/2/600_507909394.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Introducción al Pentesting
 ----
-attach: <a href="https://youtu.be/pDu87a3lr78">Video Youtube</a> / <a href="https://drive.google.com/file/d/1sgH0tlUf-eJJWp4isNgLiT7mZPfkUEQW/view?usp=sharing">Diapositivas</a>
+details: En esta charla usaremos Python como herramienta para atacar sistemas usando la metodología del Pentesting.
+----
+speaker: sergio-molinares
+----
+speaker_name: 
+----
+speaker_bio: Tecnologo en sistemas, apasionado de la seguridad informática, desarrollador Python en desarrollo, con muy buena experiencia en infraestructura, ccna cisco, We speake security, redteam, ctf player, investigador en el área de la seguridad
+----
+attach: <a href="https://drive.google.com/file/d/1sgH0tlUf-eJJWp4isNgLiT7mZPfkUEQW/view?usp=sharing">Diapositivas</a>
+---
+youtube: pDu87a3lr78

--- a/content/eventos/2022-11-30-crea-tus-propias-videollamadas-con-python-y-webrtc/contents.lr
+++ b/content/eventos/2022-11-30-crea-tus-propias-videollamadas-con-python-y-webrtc/contents.lr
@@ -21,6 +21,9 @@ speaker_name:
 ----
 speaker_bio: Soy programador Python con título en Ingeniería de Sistemas de la CUES. Con mas de 7 años de experiencia laboral en campos como la robótica y el streaming de multimedia.
 ----
-attach: <a href="https://drive.google.com/file/d/1WYbWcpyNCRr-D914ifhtQYG7l7NPHjMA/view?usp=sharing">Diapositivas</a>
+attach:
+
+- [Diapositivas](https://drive.google.com/file/d/1WYbWcpyNCRr-D914ifhtQYG7l7NPHjMA/view?usp=sharing)
+- [GitHub](https://github.com/GudarJs/webrtc-python-demo-pybaq-2022)
 ---
 youtube: XtJncjNegvQ

--- a/content/eventos/2022-11-30-crea-tus-propias-videollamadas-con-python-y-webrtc/contents.lr
+++ b/content/eventos/2022-11-30-crea-tus-propias-videollamadas-con-python-y-webrtc/contents.lr
@@ -4,13 +4,23 @@ date_start: 2022-11-30 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/289816044/
 ---
-information: <p>¿Te gustaría conocer como funcionan las aplicaciones de videollamadas que conectaron al mundo en tiempo de crisis y que ahora se han vuelto parte de nuestro día a día?<br/>En esta charla aprenderás ¿qué es WebRTC? ¿cómo funciona?, sus usos, algunas curiosidades y veras una demostración de lo que podrías crear usando esta tecnología.</p> <p>Ponente: Dario Guzman</p> <p>Soy programador Python con título en Ingeniería de Sistemas de la CUES. Con mas de 7 años de experiencia laboral en campos como la robótica y el streaming de multimedia.</p> <p>***</p> <p>Adicionales:</p> <p>* Transmitiremos por el canal del YouTube de Python Colombia.<br/>* Suscríbete y dale click a la campanita para estar pendiente de eventos de otras comunidades de Python en Colombia xD</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/8/9/b/5/600_508655253.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Crea tus propias videollamadas con Python y WebRTC
 ----
-attach: <a href="https://youtu.be/XtJncjNegvQ">Video Youtube</a> / <a href="https://drive.google.com/file/d/1WYbWcpyNCRr-D914ifhtQYG7l7NPHjMA/view?usp=sharing">Diapositivas</a>
+details: ¿Te gustaría conocer como funcionan las aplicaciones de videollamadas que conectaron al mundo en tiempo de crisis y que ahora se han vuelto parte de nuestro día a día?<br/>En esta charla aprenderás ¿qué es WebRTC? ¿cómo funciona?, sus usos, algunas curiosidades y veras una demostración de lo que podrías crear usando esta tecnología.
+----
+speaker: dario-guzman
+----
+speaker_name: 
+----
+speaker_bio: Soy programador Python con título en Ingeniería de Sistemas de la CUES. Con mas de 7 años de experiencia laboral en campos como la robótica y el streaming de multimedia.
+----
+attach: <a href="https://drive.google.com/file/d/1WYbWcpyNCRr-D914ifhtQYG7l7NPHjMA/view?usp=sharing">Diapositivas</a>
+---
+youtube: XtJncjNegvQ

--- a/content/eventos/2022-12-22-de-psicologo-a-programador-cambio-o-complemento-de-carrera/contents.lr
+++ b/content/eventos/2022-12-22-de-psicologo-a-programador-cambio-o-complemento-de-carrera/contents.lr
@@ -4,13 +4,23 @@ date_start: 2022-12-22 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/290329689/
 ---
-information: <p>En "De psicólogo a programador ¿Cambio o complemento de carrera?" Julián establece un puente entre el desarrollo de software y la psicología. El contacto con la tecnología puede causar problemas psicológicos o ser la solución, es por eso que, para Julián y nuestra comunidad de python Barranquilla, es clave generar espacios de encuentro en donde juntos buscamos nuevas y mejores formas de trabajar juntos.</p> <p>Ponente: Julián Casadiego</p> <p>Cursa en la actualidad la Maestría en Recursos Humanos y Gestión Organizacional. Cuenta con más de 6 años de experiencia como psicólogo en instituciones públicas y privadas, desempeñando el rol de analista de factores de riesgos psicosociales. Tiene conocimiento en ciencia de datos y supervisión de desarrollo de herramientas tecnológicas de la información y la comunicación (TIC´s).</p> <p>***</p> <p>Adicionales:</p> <p>* Transmitiremos por el canal del YouTube de Python Colombia.<br/>* Suscríbete y dale click a la campanita para estar pendiente de eventos de otras comunidades de Python en Colombia xD</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/5/5/a/0/600_509241920.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: De psicólogo a programador ¿cambio o complemento de carrera?
 ----
-attach: <a href="https://youtu.be/Dzi89oXcRUg">Video Youtube</a> / <a href="https://drive.google.com/file/d/1d6CbU_B0RvFyjJzwPQ9jkmmUC0X0vBs5/view?usp=share_link">Diapositivas</a>
+details: En "De psicólogo a programador ¿Cambio o complemento de carrera?" Julián establece un puente entre el desarrollo de software y la psicología. El contacto con la tecnología puede causar problemas psicológicos o ser la solución, es por eso que, para Julián y nuestra comunidad de python Barranquilla, es clave generar espacios de encuentro en donde juntos buscamos nuevas y mejores formas de trabajar juntos.
+----
+speaker: 
+----
+speaker_name: Julián Casadiego
+----
+speaker_bio: Cursa en la actualidad la Maestría en Recursos Humanos y Gestión Organizacional. Cuenta con más de 6 años de experiencia como psicólogo en instituciones públicas y privadas, desempeñando el rol de analista de factores de riesgos psicosociales. Tiene conocimiento en ciencia de datos y supervisión de desarrollo de herramientas tecnológicas de la información y la comunicación (TIC´s).
+----
+attach: <a href="https://drive.google.com/file/d/1d6CbU_B0RvFyjJzwPQ9jkmmUC0X0vBs5/view?usp=share_link">Diapositivas</a>
+---
+youtube: Dzi89oXcRUg


### PR DESCRIPTION
# Pull request

Closes #471 

Parte de #394 


## Observaciones

Se agregan los eventos del 2022

Para el conversatorio de los 7 años de la comunidad, en charlas se agregaron los ponentes cada uno como si se tratase de una charla ya que facilita enlazar multiples ponentes de un mismo evento, ya que no habia nombre de charla en la postura de cada uno, queda vacia, y en la invitación a meetup no habian descripciones de los eventos

https://deploy-preview-498--vigilant-neumann-d109b9.netlify.app/eventos/2022-04-28-conversatorio-de-junior-a-senior-conmemorando-7-anos-de-comunidad/

Anexo github en charla de webrtc
<img width="1679" alt="image" src="https://github.com/PyBAQ/website/assets/1175402/20f2607e-bfdb-47e6-8813-be4947a2bccf">

https://deploy-preview-498--vigilant-neumann-d109b9.netlify.app/eventos/2022-11-30-crea-tus-propias-videollamadas-con-python-y-webrtc/
