### PR TITLE
Devcontainer testing

### DIFF
--- a/.devcontainer/testing/devcontainer.json
+++ b/.devcontainer/testing/devcontainer.json
@@ -1,17 +1,22 @@
 {
   "name": "Selenium Tests",
-  "dockerComposeFile": [
-      "../../compose.yaml",
-      "docker-compose.extend.yml"
-  ],
-  "service": "testing",
-  "shutdownAction": "stopCompose",
-  "workspaceFolder": "/workspace/",
+  "image": "mcr.microsoft.com/vscode/devcontainers/universal",
+  "hostRequirements": { "cpus": 2 },
+  "waitFor": "onCreateCommand",
+  "onCreateCommand": "pipx install lektor && pip install -r test-requirements.txt && npm install",
+  "postAttachCommand": {
+    "server": "lektor server",
+    "css": "npm run watch"
+  },
+  "portsAttributes": {
+      "5000": {
+      "label": "Lektor Server",
+      "onAutoForward": "openPreview"
+    }
+  },
   "forwardPorts": [4444, 5000, 7900],
-  "onCreateCommand": "pip install -r test-requirements.txt",
-  "postAttachCommand": "python -m pytest",
   "remoteEnv": {
-    "TEST_COMMAND_EXECUTOR": "http://browser:4444/wd/hub"
+    "TEST_COMMAND_EXECUTOR": "http://localhost:4444/wd/hub"
   },
   "customizations": {
     "codespaces": {

--- a/.devcontainer/testing/devcontainer.json
+++ b/.devcontainer/testing/devcontainer.json
@@ -16,7 +16,8 @@
   },
   "forwardPorts": [4444, 5000, 7900],
   "remoteEnv": {
-    "TEST_COMMAND_EXECUTOR": "http://localhost:4444/wd/hub"
+    "TEST_COMMAND_EXECUTOR": "http://localhost:4444/wd/hub",
+    "PYTEST_BASE_URL": "http://localhost:5000"
   },
   "customizations": {
     "codespaces": {

--- a/.devcontainer/testing/docker-compose.extend.yml
+++ b/.devcontainer/testing/docker-compose.extend.yml
@@ -1,9 +1,0 @@
-version: '3'
-services:
-  testing:
-    image: mcr.microsoft.com/vscode/devcontainers/python:3.11
-    volumes:
-      # Mounts the project folder to '/workspace'. While this file is in .devcontainer,
-      # mounts are relative to the first file in the list, which is a level up.
-      - .:/workspace:cached
-    command: /bin/sh -c "while sleep 1000; do :; done"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   browser:
     image: selenium/standalone-${TEST_BROWSER:-chrome}
@@ -7,9 +6,4 @@ services:
       - 4444:4444 # Selenium service
       - 5900:5900 # VNC server
       - 7900:7900 # VNC browser client
-  webapp:
-    build: ./
-    ports:
-      - 5000:5000 # Lektor
-    volumes:
-      - .:/app
+    network_mode: "host"

--- a/compose.yaml
+++ b/compose.yaml
@@ -2,8 +2,4 @@ services:
   browser:
     image: selenium/standalone-${TEST_BROWSER:-chrome}
     shm_size: '2gb'
-    ports:
-      - 4444:4444 # Selenium service
-      - 5900:5900 # VNC server
-      - 7900:7900 # VNC browser client
     network_mode: "host"


### PR DESCRIPTION
# Pull request

Relacionado a #523 

Se corrije la inicialización del codespace testing, permitiendo ejecutar pruebas sobre cambios locales

## Observaciones

![imagen](https://github.com/PyBAQ/website/assets/1175402/c1e9c3f4-56dc-41d2-97a2-7eaf7e38e130)

Una vez se ejecuta docker compose se puede usar selenium y ejecutar pytest

Cabe aclarar que codespaces no ofrece una alternativa para poder ejecutar browser, asi que usar un servicio como docker selenium driver es una alternativa bastante amigable para nuestro caso de uso, otra opción es ir a por un servicio tipo browserstack, saucelabs o kobiton

![imagen](https://github.com/PyBAQ/website/assets/1175402/dcc43d1c-2073-4f97-b486-04d937c797a8)

