### PR TITLE
Eventos 2020

### DIFF
--- a/content/eventos/2020-02-27-intro-python-django-breaking-the-enigma-what-if-turing-had-python/contents.lr
+++ b/content/eventos/2020-02-27-intro-python-django-breaking-the-enigma-what-if-turing-had-python/contents.lr
@@ -1,10 +1,19 @@
-title: Intro python & django + Breaking the enigma: what if Turing had python? 
+title:
+
+Intro python & django + Breaking the enigma: what if Turing had python? 
 ---
 date_start: 2020-02-27 19:00
 ---
 link: https://www.meetup.com/pythonbaq/events/268816451/
 ---
-information: <p>El ÚNICO REGISTRO para este evento será por el siguiente formulario<br/><a href="https://goo.gl/forms/emO5cJshnrhQsvO92" class="linkified">https://goo.gl/forms/emO5cJshnrhQsvO92</a></p> <p>---------------</p> <p>Charla: **Intro Python &amp; Django**</p> <p>En esta charla quiero hacer una introducción sobre el lenguaje Python y Django, uno de los frameworks mas populares en el desarrollo web. Cuáles son sus principales características y ventajas que lo hacen ideal para crear aplicaciones monolíticas robustas.</p> <p>Ponente: Javier Daza</p> <p>Ingeniero electrónico de la Universidad del Norte, fundador de Python Barranquilla y desarrollador de Python con más de 4 años de experiencia.</p> <p>---------------</p> <p>**Charla: Breaking the enigma: what if Turing had python?**</p> <p>In this talk I want to bring back all the cryptographic work done during the World War II regarding the deciphering of the nazi communication system. In particular, I will present a python re-creation of the Enigma machine used to encrypt messages during the war, but most importantly I will present a historically accurate python simulator of the Bombe machine used to crack this cipher.</p> <p>Ponente: Maria Camila Remoliana Gutiérrez</p> <p>Systems and computer engineer from Universidad de los Andes, also physicist from the same university with an emphasis in computational astronomy. She is very passionate learner and I enjoy spreading the knowledge to create a stronger community interested in science (both astronomical and computational).<br/>-----</p> <p>Adicionales:</p> <p>1. El evento es gratuito.<br/>2. Las charlas serán en español<br/>3. Para el acceso al edificio y ÚNICO REGISTRO de este evento, por favor diligencia este formulario<br/>( <a href="https://goo.gl/forms/emO5cJshnrhQsvO92" class="linkified">https://goo.gl/forms/emO5cJshnrhQsvO92</a>)<br/>(obligatorio para ingresar al lugar)</p> <p>Agenda:</p> <p>• 6:30-7:00pm - Llegada, networking<br/>• 7:00-7:40pm - Charla 1<br/>• 7:40-8:00pm - Receso, pizza<br/>• 8:00-8:40pm - Talk 2<br/>• 8:40-9:00pm - Cierre</p> <p>Observaciones:</p> <p>• El lugar tiene una capacidad limitada, por lo que le pedimos el favor a los que no puedan asistir que se den de baja de la lista de confirmados, para que otras personas tengan la oportunidad de participar.</p> <p>* La pizza es GRATIS gracias a PYTHON SOFTWARE FOUNDATION.</p> 
+information:
+
+Agenda:
+* 6:30-7:00pm - Llegada, networking
+* 7:00-7:40pm - Charla 1
+* 7:40-8:00pm - Receso, pizza
+* 8:00-8:40pm - Talk 2
+* 8:40-9:00pm - Cierre
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/4/4/d/c/600_489137628.jpeg
 ---
@@ -12,9 +21,29 @@ venue: Koombea
 ---
 address_1: Calle 85 # 53-14
 ---
-talks: 
+talks:
 
 #### talk ####
-title: Intro python & django + Breaking the enigma: what if Turing had python? 
+title: Intro python & django
+----
+details: En esta charla quiero hacer una introducción sobre el lenguaje Python y Django, uno de los frameworks mas populares en el desarrollo web. Cuáles son sus principales características y ventajas que lo hacen ideal para crear aplicaciones monolíticas robustas.
+----
+speaker: javier-daza
+----
+speaker_name: 
+----
+speaker_bio: Ingeniero electrónico de la Universidad del Norte, fundador de Python Barranquilla y desarrollador de Python con más de 4 años de experiencia.
+----
+attach: Systems and computer engineer from Universidad de los Andes, also physicist from the same university with an emphasis in computational astronomy. She is very passionate learner and I enjoy spreading the knowledge to create a stronger community interested in science (both astronomical and computational)
+#### talk ####
+title: Breaking the enigma: what if Turing had python?
+----
+details: In this talk I want to bring back all the cryptographic work done during the World War II regarding the deciphering of the nazi communication system. In particular, I will present a python re-creation of the Enigma machine used to encrypt messages during the war, but most importantly I will present a historically accurate python simulator of the Bombe machine used to crack this cipher.
+----
+speaker: 
+----
+speaker_name: Maria Camila Remoliana Gutiérrez
+----
+speaker_bio: 
 ----
 attach: 

--- a/content/eventos/2020-02-27-intro-python-django-breaking-the-enigma-what-if-turing-had-python/contents.lr
+++ b/content/eventos/2020-02-27-intro-python-django-breaking-the-enigma-what-if-turing-had-python/contents.lr
@@ -12,7 +12,7 @@ Agenda:
 * 6:30-7:00pm - Llegada, networking
 * 7:00-7:40pm - Charla 1
 * 7:40-8:00pm - Receso, pizza
-* 8:00-8:40pm - Talk 2
+* 8:00-8:40pm - Charla 2
 * 8:40-9:00pm - Cierre
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/4/4/d/c/600_489137628.jpeg
@@ -34,7 +34,7 @@ speaker_name:
 ----
 speaker_bio: Ingeniero electrónico de la Universidad del Norte, fundador de Python Barranquilla y desarrollador de Python con más de 4 años de experiencia.
 ----
-attach: Systems and computer engineer from Universidad de los Andes, also physicist from the same university with an emphasis in computational astronomy. She is very passionate learner and I enjoy spreading the knowledge to create a stronger community interested in science (both astronomical and computational)
+attach: 
 #### talk ####
 title: Breaking the enigma: what if Turing had python?
 ----
@@ -44,6 +44,6 @@ speaker:
 ----
 speaker_name: Maria Camila Remoliana Gutiérrez
 ----
-speaker_bio: 
+speaker_bio: Systems and computer engineer from Universidad de los Andes, also physicist from the same university with an emphasis in computational astronomy. She is very passionate learner and I enjoy spreading the knowledge to create a stronger community interested in science (both astronomical and computational)
 ----
 attach: 

--- a/content/eventos/2020-03-31-online-the-best-of-both-worlds-r-meets-python-pybaq-5-anos/contents.lr
+++ b/content/eventos/2020-03-31-online-the-best-of-both-worlds-r-meets-python-pybaq-5-anos/contents.lr
@@ -4,13 +4,35 @@ date_start: 2020-03-31 19:00
 ---
 link: https://www.meetup.com/pythonbaq/events/269517260/
 ---
-information: <p>Este es el enlace de la reunión<br/><a href="https://koombea.zoom.us/j/945190987" class="linkified">https://koombea.zoom.us/j/945190987</a></p> <p>También se transmitirá por facebook.</p> <p>Charla:**The best of both worlds: R meets Python! 🤝**</p> <p>La charla busca comparar en el contexto de la *ciencia de datos*, un lenguaje de propósito general como Python contra uno de propósito específico como R. El objetivo antes que declarar un "ganador", es resaltar las bondades y limitaciones de cada herramienta en un conjunto de situaciones reales de uso; de tal forma que los usuarios puedan seleccionar la más adecuada.</p> <p>Ponente: Emilio Berdugo Camacho</p> <p>Licenciado en matemáticas y física de la Universidad del Atlántico.<br/>Magíster en Estadística, Universidad Nacional sede Bogotá.<br/>Docente de las Universidades Nacional, Santo Tomás y Distrital en Bogotá. Consultor y asesor en analítica avanzada y CIENCIA DE DATOS para instituciones como el ICFES, EJÉRCITO NACIONAL y Grupo AVAL, entre otros. Director del área ANALÍTICA y Minería de datos para muebles JAMAR. Investigador con diversas publicaciones en áreas como: Estadística y minería de datos.</p> <p>---------------</p> <p>**🎂🎂 Happy BirthDay!! PyBAQ 🎉🎉🎊**</p> <p>Queremos recordar y compartir con todos los asistentes los 5 años que cumple la comunidad de Python Barranquilla. Estamos contentos de haber tenido la oportunidad de brindar este espacio para compartir conocimiento sobre tecnología 💻, ciencias aplicadas 👨‍🔬👩‍🔬 y otros temas pero sobre todo para conocer personas y hacer nuevos amigos 🖖 . Somos una comunidad diversa 👳‍♂👳‍♂👳‍♀👲🧕🧔🧓👴🤓 que a lo largo de estos 5 años no hemos parado de crecer; queremos agradecerles a todas* ustedes por hacer parte, por asistir a los eventos, a los ponentes por su tiempo y brindarnos su conocimiento y en general, a todos las que hacen parte del comunidad!<br/>Este es un momento que queremos compartir con todos ustedes, por lo cual la 🍻🥂 celebración 🎂🍰 quedará *aplazada* hasta que se supere la situación actual con el COVID-19</p> <p>-----</p> <p>Adicionales:</p> <p>1. El evento es gratuito.<br/>2. Las charlas serán en español<br/>3. Este mes la charla será *ONLINE*; el link para unirse a la conferencia lo compartiremos por este medio. Así que que ponte cómoda* desde casa y que la disfruten</p> <p>Observaciones:</p> <p>* En este texto se hace uso de tanto el femenino como el masculino para indicar neutralidad! 😄<br/>* La pizza es GRATIS gracias a PYTHON SOFTWARE FOUNDATION. El meetup va a ser online así que este mes no habrá pizza 😔</p> 
+information:
+
+**🎂🎂 Happy BirthDay!! PyBAQ 🎉🎉🎊**
+
+Queremos recordar y compartir con todos los asistentes los 5 años que cumple la comunidad de Python Barranquilla. Estamos contentos de haber tenido la oportunidad de brindar este espacio para compartir conocimiento sobre tecnología 💻, ciencias aplicadas 👨‍🔬👩‍🔬 y otros temas pero sobre todo para conocer personas y hacer nuevos amigos 🖖 . Somos una comunidad diversa 👳‍♂👳‍♂👳‍♀👲🧕🧔🧓👴🤓 que a lo largo de estos 5 años no hemos parado de crecer; queremos agradecerles a todas* ustedes por hacer parte, por asistir a los eventos, a los ponentes por su tiempo y brindarnos su conocimiento y en general, a todos las que hacen parte del comunidad!
+
+Este es un momento que queremos compartir con todos ustedes, por lo cual la 🍻🥂 celebración 🎂🍰 quedará *aplazada* hasta que se supere la situación actual con el COVID-19
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/b/1/f/f/600_489825567.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
-title: 📣 [ONLINE] 👨‍💻👩‍💻The Best of Both worlds: R meets Python 🎂 PyBAQ 5 años 🎉
+title: The Best of Both worlds: R meets Python
 ----
-attach: <a href="https://www.facebook.com/watch/?v=274039276919040">Video Facebook</a>
+details: La charla busca comparar en el contexto de la *ciencia de datos*, un lenguaje de propósito general como Python contra uno de propósito específico como R. El objetivo antes que declarar un "ganador", es resaltar las bondades y limitaciones de cada herramienta en un conjunto de situaciones reales de uso; de tal forma que los usuarios puedan seleccionar la más adecuada.
+----
+speaker: 
+----
+speaker_name: Emilio Berdugo Camacho
+----
+speaker_bio:
+
+Licenciado en matemáticas y física de la Universidad del Atlántico.
+
+Magíster en Estadística, Universidad Nacional sede Bogotá
+
+Docente de las Universidades Nacional, Santo Tomás y Distrital en Bogotá. Consultor y asesor en analítica avanzada y CIENCIA DE DATOS para instituciones como el ICFES, EJÉRCITO NACIONAL y Grupo AVAL, entre otros. Director del área ANALÍTICA y Minería de datos para muebles JAMAR. Investigador con diversas publicaciones en áreas como: Estadística y minería de datos.
+----
+attach: 
+---
+attach: Evento transmitido via [Facebook](https://www.facebook.com/watch/?v=274039276919040)

--- a/content/eventos/2020-04-30-online-por-que-kubernetes-implementa-scrum-en-organizaciones/contents.lr
+++ b/content/eventos/2020-04-30-online-por-que-kubernetes-implementa-scrum-en-organizaciones/contents.lr
@@ -4,13 +4,35 @@ date_start: 2020-04-30 19:00
 ---
 link: https://www.meetup.com/pythonbaq/events/270177332/
 ---
-information: <p>Será por Zoom y también se transmitirá por facebook.</p> <p><a href="https://koombea.zoom.us/j/97033531876?pwd=eUNMQ0F4VVprNFpuZm9YRytWRDVoQT09" class="linkified">https://koombea.zoom.us/j/97033531876?pwd=eUNMQ0F4VVprNFpuZm9YRytWRDVoQT09</a></p> <p>ID de la reunión:[masked]<br/>Contraseña: 6WP8HP</p> <p>Charla 1:**Por qué todo el mundo quiere usar kubernetes**</p> <p>Un pequeño resumen de qué es kubernetes y para qué sirve, si aun no lo conoces. Asimismo, veremos por qué se convierte en la plataforma favorita de muchos equipos de trabajo para la gestión de contenedores. Además, hablaremos de los problemas que he podido solucionar con esta herramienta y cómo puedes comenzar a utilizarla desde ya en tus ambientes productivos.</p> <p>Ponente: Jesús David Diaz</p> <p>Soy estudiante de ingeniería de sistemas con 3 años de experiencia en el desarrolla de software. Apasionado por la tecnología y la ingeniería de software. Actualmente trabajo para Maestrik, como software developer. Con gran énfasis devops.</p> <p>---------------</p> <p>Charla 2: **Implementando Scrum en las organizaciones: Aciertos y errores**</p> <p>Implementar Scrum en organizaciones donde se usan metodologías tradicionales es un desafío importante. Está charla busca introducir los conceptos básicos de Scrum y recopila una serie de aciertos y errores que puedes tener en cuenta a la hora de adoptar Scrum en tu organización o incluso en tu trabajo diario.</p> <p>Ponente: Brayan García</p> <p>Soy ingeniero de sistemas graduado de la Universidad de la Costa, Scrum Master y product Owner certificado, y pertenezco al equipo de organizadores de Python Barranquilla. Tengo más de 6 años de experiencia liderando proyectos de Tecnología y un par de años diseñando soluciones de TI en diferentes sectores como servicios públicos, logística, ventas, entre otros.</p> <p>-----</p> <p>Adicionales:</p> <p>1. El evento es gratuito.<br/>2. Las charlas serán en español<br/>3. Este mes la charla será *ONLINE*. El enlace para unirse a la conferencia lo compartiremos por este medio. Así que que ponte cómoda* desde casa y que la disfruten</p> <p>Observaciones:</p> <p>* En este texto se hace uso de tanto el femenino como el masculino para indicar neutralidad! 😄</p> 
+information: En este evento tuvimos 2 charlas las cuales puedes ver a continuación
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/e/0/c/2/600_490197538.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
-title: 📣 [ONLINE] 👨‍💻👩‍💻¿Por qué Kubernetes? & Implementa Scrum en organizaciones
+title: Por qué todo el mundo quiere usar kubernetes
 ----
-attach: <a href="https://drive.google.com/file/d/1Srd91Y-nAwU_RV3IY0ZWnN4SAa4Sn7ed/view?usp=sharing">Diapositivas SCRUM</a> / <a href="https://slides.com/jesusdaviddiaz/por-que-todo-el-mundo-quiere-usar-kubernetes/fullscreen">Diapositivas Kubernetes</a> / <a href="https://www.facebook.com/watch/?v=2919451251483961">Video Facebook</a>
+details: Un pequeño resumen de qué es kubernetes y para qué sirve, si aun no lo conoces. Asimismo, veremos por qué se convierte en la plataforma favorita de muchos equipos de trabajo para la gestión de contenedores. Además, hablaremos de los problemas que he podido solucionar con esta herramienta y cómo puedes comenzar a utilizarla desde ya en tus ambientes productivos.
+----
+speaker: 
+----
+speaker_name: Jesús David Diaz
+----
+speaker_bio: Soy estudiante de ingeniería de sistemas con 3 años de experiencia en el desarrolla de software. Apasionado por la tecnología y la ingeniería de software. Actualmente trabajo para Maestrik, como software developer. Con gran énfasis devops.
+----
+attach: [Diapositivas]("https://slides.com/jesusdaviddiaz/por-que-todo-el-mundo-quiere-usar-kubernetes/fullscreen)
+#### talk ####
+title: Implementando Scrum en las organizaciones: Aciertos y errores
+----
+details: Implementar Scrum en organizaciones donde se usan metodologías tradicionales es un desafío importante. Está charla busca introducir los conceptos básicos de Scrum y recopila una serie de aciertos y errores que puedes tener en cuenta a la hora de adoptar Scrum en tu organización o incluso en tu trabajo diario.
+----
+speaker: brayan-garcia
+----
+speaker_name: 
+----
+speaker_bio: Soy ingeniero de sistemas graduado de la Universidad de la Costa, Scrum Master y product Owner certificado, y pertenezco al equipo de organizadores de Python Barranquilla. Tengo más de 6 años de experiencia liderando proyectos de Tecnología y un par de años diseñando soluciones de TI en diferentes sectores como servicios públicos, logística, ventas, entre otros.
+----
+attach: [Diapositivas](https://drive.google.com/file/d/1Srd91Y-nAwU_RV3IY0ZWnN4SAa4Sn7ed/view?usp=sharing)
+---
+attach: Este evento fue transmitido por [Facebook](https://www.facebook.com/watch/?v=2919451251483961)

--- a/content/eventos/2020-06-26-7-tecnicas-para-sacarle-el-maximo-potencial-a-django-rest-framework/contents.lr
+++ b/content/eventos/2020-06-26-7-tecnicas-para-sacarle-el-maximo-potencial-a-django-rest-framework/contents.lr
@@ -4,13 +4,23 @@ date_start: 2020-06-26 19:00
 ---
 link: https://www.meetup.com/pythonbaq/events/271397218/
 ---
-information: <p>Será por Zoom y también se transmitirá por facebook.</p> <p>** <a href="https://koombea.zoom.us/j/93808783699?pwd=c0FwMFNYMW03VHYwM1huclNLQWsvdz09" class="linkified">https://koombea.zoom.us/j/93808783699?pwd=c0FwMFNYMW03VHYwM1huclNLQWsvdz09</a></p> <p>Contraseña: 6WP8HP</p> <p>Charla:**7 técnicas para sacarle el máximo potencial a Django REST Framework.**</p> <p>Esta charla hace parte una serie de charlas donde haremos un proyecto con Django channels y GIS para crear una aplicación estilo Uber. En esta primera parte veremos diferentes técnicas para llevar tu conocimiento de DRF básico al siguiente nivel</p> <p>Ponente: Oswaldo Rodriguez</p> <p>CTO en WOGO, desarrollador Backend con más de 6 años de experiencia en Python y colaborador frecuente de la comunidad PyBAQ.</p> <p>-----</p> <p>Adicionales:</p> <p>1. El evento es gratuito.<br/>2. Las charlas serán en español<br/>3. Este mes la charla será *ONLINE*.<br/>4. Transmitiremos la charla por YouTube</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/9/c/d/1/600_491020145.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: 7 técnicas para sacarle el máximo potencial a Django REST Framework
 ----
-attach: <a href="https://drive.google.com/file/d/1u09Vh_QUNP9Je6vrpDHNK6SFOpb5zYa5/view?usp=sharing">Diapositivas</a> / <a href="https://youtu.be/T90qyrcHvqM">Video Youtube</a>
+details: Esta charla hace parte una serie de charlas donde haremos un proyecto con Django channels y GIS para crear una aplicación estilo Uber. En esta primera parte veremos diferentes técnicas para llevar tu conocimiento de DRF básico al siguiente nivel
+----
+speaker: oswaldo-rodriguez
+----
+speaker_name: 
+----
+speaker_bio: CTO en WOGO, desarrollador Backend con más de 6 años de experiencia en Python y colaborador frecuente de la comunidad PyBAQ.
+----
+attach: [Diapositivas](https://drive.google.com/file/d/1u09Vh_QUNP9Je6vrpDHNK6SFOpb5zYa5/view?usp=sharing)
+---
+youtube: T90qyrcHvqM

--- a/content/eventos/2020-07-02-python-y-devnet-aplicabilidad-en-la-programabilidad-de-redes/contents.lr
+++ b/content/eventos/2020-07-02-python-y-devnet-aplicabilidad-en-la-programabilidad-de-redes/contents.lr
@@ -4,13 +4,23 @@ date_start: 2020-07-02 19:00
 ---
 link: https://www.meetup.com/pythonbaq/events/271603509/
 ---
-information: <p>Via Zoom y transmisión en Youtube</p> <p>** <a href="https://koombea.zoom.us/j/92786706824?pwd=ZzJnMFVya0hKUFNYK04xaW9VRHZpdz09" class="linkified">https://koombea.zoom.us/j/92786706824?pwd=ZzJnMFVya0hKUFNYK04xaW9VRHZpdz09</a></p> <p>Contraseña: 6WP8HP</p> <p>Charla:**Python y DevNet: Aplicabilidad en la programabilidad de redes.**</p> <p>Destacaremos la importancia, rol y uso de herramientas para la programación y automatización de ecosistemas de redes con Python.</p> <p>Ponente: Yuliana Martinez</p> <p>Ingeniera Telemática de la institución Universitaria ITSA, con experiencia en Soporte Técnico y Servicio al Cliente en Seguridad de Red, Voz sobre IP, y otros servicios de Telecomunicaciones. Colaboradora en la comunidad de Python Barranquilla.</p> <p>-----</p> <p>Adicionales:</p> <p>1. El evento es gratuito.<br/>2. Las charlas serán en español<br/>3. Este mes la charla será *ONLINE*.<br/>4. Transmitiremos la charla por el canal del YouTube de Python Colombia</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/c/0/b/a/600_491089338.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Python y DevNet: Aplicabilidad en la programabilidad de redes
 ----
-attach: <a href="https://drive.google.com/file/d/15pBxVLMz0ntGsRnSqn7PDIrq4YsLJGUp/view?usp=sharing">Diapositivas</a> / <a href="https://www.youtube.com/watch?v=NW7_U_wljic">Video Youtube</a>
+details: Destacaremos la importancia, rol y uso de herramientas para la programación y automatización de ecosistemas de redes con Python.
+----
+speaker: yuliana-martinez
+----
+speaker_name: 
+----
+speaker_bio: Ingeniera Telemática de la institución Universitaria ITSA, con experiencia en Soporte Técnico y Servicio al Cliente en Seguridad de Red, Voz sobre IP, y otros servicios de Telecomunicaciones. Colaboradora en la comunidad de Python Barranquilla.
+----
+attach: [Diapositivas](https://drive.google.com/file/d/15pBxVLMz0ntGsRnSqn7PDIrq4YsLJGUp/view?usp=sharing)
+---
+youtube: NW7_U_wljic

--- a/content/eventos/2020-08-13-manejo-de-archivos-grandes-con-una-django-app-drf/contents.lr
+++ b/content/eventos/2020-08-13-manejo-de-archivos-grandes-con-una-django-app-drf/contents.lr
@@ -4,13 +4,29 @@ date_start: 2020-08-13 19:00
 ---
 link: https://www.meetup.com/pythonbaq/events/272483658/
 ---
-information: <p>Via Zoom y transmisión en Youtube</p> <p><a href="https://koombea.zoom.us/j/95290884169?pwd=SkRXWHo1U0ZLc0pVcFFxSU5Gem5KZz09" class="linkified">https://koombea.zoom.us/j/95290884169?pwd=SkRXWHo1U0ZLc0pVcFFxSU5Gem5KZz09</a><br/>Meeting ID:[masked]<br/>Passcode: 6WP8HP</p> <p>Charla:**Manejo de archivos grandes con una Django &amp; DRF.**</p> <p>En esta charla conoceremos algunas de las alternativas para realizar subidas y descargas de archivos en un contexto de una API REST. Profundizaremos en los componentes y configuraciones que propone django y django rest framework para manejar este tipo de procesos. Por último revisaremos configuraciones útiles de uwsgi y ngnix para cuando llevemos a producción aplicaciones que provean este tipo de servicios.</p> <p>Ponente: Emiliano Martín</p> <p>Mi nombre es Emiliano Martín, tengo 28 años y vivo en Córdoba, Argentina. Estudié Ingeniería en Sistemas de Información en la UTN y actualmente trabajo en Mercadolibre como Sr. Software Engineer.<br/>Me apasiona el desarrollo de software en general, me gusta estar en un constante aprendizaje de nuevas tecnologías y buenas prácticas de programación.<br/>En 2015 comencé mi camino profesional en MercadoLibre principalmente como Desarrollador Backend Java en el área de prevención de fraude. Luego en 2017 tuve la posibilidad de emigrar al equipo de prevención de lavado de dinero, en donde además de desarrollar backend con Java, incursioné en el desarrollo frontend con NodeJS y ReactJS. Por último, en 2019 y hasta la actualidad, logré dar un giro en mi carrera y dedicarme full time a desarrollar Python como MLOps en el área de Machine Learning Technology, lenguaje que me gusta mucho y lo utilizaba en proyectos fuera de MercadoLibre.</p> <p>-----</p> <p>Adicionales:</p> <p>1. El evento es gratuito.<br/>2. La charla será en español<br/>3. Este mes la charla será *ONLINE*.<br/>4. Transmitiremos la charla por el canal del YouTube de Python Colombia</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/d/4/3/9/600_491754329.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Manejo de archivos grandes con una Django app & DRF
 ----
-attach: <a href="https://drive.google.com/file/d/1HJTkMmzHf0hc6gDeAo2FDdP07qon69ve/view?usp=sharing">Diapositivas</a> / <a href="https://www.youtube.com/watch?v=xFbdytRPK9Q">Video Youtube</a>
+details: En esta charla conoceremos algunas de las alternativas para realizar subidas y descargas de archivos en un contexto de una API REST. Profundizaremos en los componentes y configuraciones que propone django y django rest framework para manejar este tipo de procesos. Por último revisaremos configuraciones útiles de uwsgi y ngnix para cuando llevemos a producción aplicaciones que provean este tipo de servicios.
+----
+speaker: 
+----
+speaker_name: Emiliano Martín
+----
+speaker_bio:
+
+Mi nombre es Emiliano Martín, tengo 28 años y vivo en Córdoba, Argentina. Estudié Ingeniería en Sistemas de Información en la UTN y actualmente trabajo en Mercadolibre como Sr. Software Engineer.
+
+Me apasiona el desarrollo de software en general, me gusta estar en un constante aprendizaje de nuevas tecnologías y buenas prácticas de programación.
+
+En 2015 comencé mi camino profesional en MercadoLibre principalmente como Desarrollador Backend Java en el área de prevención de fraude. Luego en 2017 tuve la posibilidad de emigrar al equipo de prevención de lavado de dinero, en donde además de desarrollar backend con Java, incursioné en el desarrollo frontend con NodeJS y ReactJS. Por último, en 2019 y hasta la actualidad, logré dar un giro en mi carrera y dedicarme full time a desarrollar Python como MLOps en el área de Machine Learning Technology, lenguaje que me gusta mucho y lo utilizaba en proyectos fuera de MercadoLibre.
+----
+attach: [Diapositivas](https://drive.google.com/file/d/1HJTkMmzHf0hc6gDeAo2FDdP07qon69ve/view?usp=sharing)
+---
+youtube: xFbdytRPK9Q

--- a/content/eventos/2020-09-29-geodjango-aprovechando-las-funciones-geograficas-para-tus-aplicaciones/contents.lr
+++ b/content/eventos/2020-09-29-geodjango-aprovechando-las-funciones-geograficas-para-tus-aplicaciones/contents.lr
@@ -4,13 +4,23 @@ date_start: 2020-09-29 19:00
 ---
 link: https://www.meetup.com/pythonbaq/events/273418919/
 ---
-information: <p>Via transmisión en Youtube</p> <p>Charla:**Geodjango: Aprovechando las funciones geográficas para tus aplicaciones.**</p> <p>En este espacio exploraremos el potencial de Geodjango a la hora de crear aplicaciones que necesiten explotar los datos geográficos de los usuarios y realizaremos una aplicación práctica de como aprovecharlo al máximo.</p> <p>Ponente: Oswaldo Rodriguez</p> <p>Desarrollador Backend con más de 6 años de experiencia en Python y colaborador frecuente de la comunidad PyBaq.</p> <p>-----</p> <p>Adicionales:</p> <p>1. El evento es gratuito.<br/>2. La charla será en español<br/>3. Este mes la charla será *ONLINE*.<br/>4. Transmitiremos la charla por el canal del YouTube de Python Colombia</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/a/9/9/0/600_492463408.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Geodjango: Aprovechando las funciones geográficas para tus aplicaciones
 ----
-attach: <a href="https://www.youtube.com/watch?v=piSDhPAswHs">Video Youtube</a>
+details: En este espacio exploraremos el potencial de Geodjango a la hora de crear aplicaciones que necesiten explotar los datos geográficos de los usuarios y realizaremos una aplicación práctica de como aprovecharlo al máximo.
+----
+speaker: oswaldo-rodriguez
+----
+speaker_name: 
+----
+speaker_bio: Desarrollador Backend con más de 6 años de experiencia en Python y colaborador frecuente de la comunidad PyBaq.
+----
+attach: 
+---
+youtube: piSDhPAswHs

--- a/content/eventos/2020-10-21-edicion-hacktoberfest-unete-a-traducir-la-documentacion-de-python/contents.lr
+++ b/content/eventos/2020-10-21-edicion-hacktoberfest-unete-a-traducir-la-documentacion-de-python/contents.lr
@@ -4,13 +4,23 @@ date_start: 2020-10-21 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/273911034/
 ---
-information: <p>Via transmisión en Youtube</p> <p>Charla:**Únete a traducir la documentación de Python **</p> <p>Hablaremos sobre el proyecto para traducir la documentación de Python al español, su historia, como ha ido avanzando y se hará un tutorial de cómo se puede contribuir. Muy útil para aquellos pythonistas participando en Hacktoberfest</p> <p>Ponente: Bruno Geninatti</p> <p>Casi Licenciado en Economía. Toco la guitarra casi tanto tiempo como el que me paso programando. Empecé a aprender Python de forma autodidacta hace 8 años. Encontré en el lenguaje y la comunidad de python un excelente lugar para aprender y conocer gente fabulosa. Soy miembro de la Asociación Civil Python Argentina y participo del proyecto PythonDocEs desde mayo de este año.</p> <p>-----</p> <p>Adicionales:</p> <p>1. El evento es gratuito.<br/>2. La charla será en español<br/>3. Este mes la charla será *ONLINE*.<br/>4. Transmitiremos la charla por el canal del YouTube de Python Colombia</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/c/6/a/2/600_493010850.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
-title: Edición Hacktoberfest: "Únete a traducir la documentación de Python"
+title: Únete a traducir la documentación de Python
 ----
-attach: <a href="http://maureira.xyz/python-docs-es/index.html#/">Slides</a> / <a href="https://youtu.be/YmwSdVVF8BM">Video Youtube</a>
+details: Hablaremos sobre el proyecto para traducir la documentación de Python al español, su historia, como ha ido avanzando y se hará un tutorial de cómo se puede contribuir. Muy útil para aquellos pythonistas participando en Hacktoberfest
+----
+speaker: 
+----
+speaker_name: Bruno Geninatti
+----
+speaker_bio: Casi Licenciado en Economía. Toco la guitarra casi tanto tiempo como el que me paso programando. Empecé a aprender Python de forma autodidacta hace 8 años. Encontré en el lenguaje y la comunidad de python un excelente lugar para aprender y conocer gente fabulosa. Soy miembro de la Asociación Civil Python Argentina y participo del proyecto PythonDocEs desde mayo de este año.
+----
+attach: 
+---
+youtube: YmwSdVVF8BM

--- a/content/eventos/2020-10-29-automatizacion-de-redes-con-python/contents.lr
+++ b/content/eventos/2020-10-29-automatizacion-de-redes-con-python/contents.lr
@@ -4,13 +4,33 @@ date_start: 2020-10-29 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/273775924/
 ---
-information: <p>Via transmisión en Youtube</p> <p>Charla:**Automatización de Redes con Python**</p> <p>La charla tiene como finalidad dar a conocer a la comunidad una nueva perspectiva sobre el uso de Python en el área de redes y telecomunicaciones, dado la reciente evolución que esta teniendo la gestión de la red a través de nuevos paradigmas como SDN (redes definidas por software), se prevé que los ingenieros de redes o administradores de red cuenten con habilidades básicas de programación para satisfacer esta reciente demanda, para ello surge una evolución de este nuevo rol llamado NetDevOps, el cual debe satisfacer estos nuevos retos en la gestión de la red.</p> <p>Es por esto que se mostraran las principales librerías en Python para la automatización de la red, así como los principales entornos de laboratorio de redes y casos de uso basados en mi experiencia personal aplicando estas habilidades.</p> <p>Ponente: Aristides Cabana Gomez</p> <p>Soy Ingeniero de Sistemas de la Universidad del Magdalena, con mas de 8 años de experiencia laboral distribuidos en la industria de las telecomunicaciones, cajas de compensación familiar y recientemente en el sector salud, con especialidad desempeñando cargos en las áreas de las redes y telecomunicaciones e infraestructura de TIC. También soy desarrollador Python con 8 años de experiencia en automatización y scripting aplicado en telefonía IP (AGI/AMI para Asterisk), monitorización de infraestructura TI (Plugins para Nagios), herramientas TIC open source (GLPI, Glassfish, etc...) y networking (Backup y Gestión de la configuración para dispositivos Cisco y Allied Telesis).</p> <p>Comparto mi perfil profesional en la red Linkedin: <a href="https://www.linkedin.com/in/aristides-cabana" class="linkified">https://www.linkedin.com/in/aristides-cabana</a>- gomez[masked]/</p> <p>-----</p> <p>Adicionales:</p> <p>1. El evento es gratuito.<br/>2. La charla será en español<br/>3. Este mes la charla será *ONLINE*.<br/>4. Transmitiremos la charla por el canal del YouTube de Python Colombia</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/7/6/3/e/600_492870270.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: Automatización de Redes con Python
 ----
-attach: <a href="https://drive.google.com/file/d/1RuamS46QNQggeiZdVfGk0dbMbvn6bxUn/view?usp=sharing">Diapositivas</a> / <a href="https://drive.google.com/file/d/1roE-5BppgmpcAOOSZaxAve1bCBHQ70R1/view?usp=sharing">Recursos</a> / <a href="https://youtu.be/XUiIGJNdqlo">Video Youtube</a>
+details:
+
+La charla tiene como finalidad dar a conocer a la comunidad una nueva perspectiva sobre el uso de Python en el área de redes y telecomunicaciones, dado la reciente evolución que esta teniendo la gestión de la red a través de nuevos paradigmas como SDN (redes definidas por software), se prevé que los ingenieros de redes o administradores de red cuenten con habilidades básicas de programación para satisfacer esta reciente demanda, para ello surge una evolución de este nuevo rol llamado NetDevOps, el cual debe satisfacer estos nuevos retos en la gestión de la red.
+Es por esto que se mostraran las principales librerías en Python para la automatización de la red, así como los principales entornos de laboratorio de redes y casos de uso basados en mi experiencia personal aplicando estas habilidades.
+----
+speaker: 
+----
+speaker_name: Aristides Cabana Gomez
+----
+speaker_bio:
+
+Soy Ingeniero de Sistemas de la Universidad del Magdalena, con mas de 8 años de experiencia laboral distribuidos en la industria de las telecomunicaciones, cajas de compensación familiar y recientemente en el sector salud, con especialidad desempeñando cargos en las áreas de las redes y telecomunicaciones e infraestructura de TIC. También soy desarrollador Python con 8 años de experiencia en automatización y scripting aplicado en telefonía IP (AGI/AMI para Asterisk), monitorización de infraestructura TI (Plugins para Nagios), herramientas TIC open source (GLPI, Glassfish, etc...) y networking (Backup y Gestión de la configuración para dispositivos Cisco y Allied Telesis).
+
+[Linkedin](https://www.linkedin.com/in/aristides-cabana)
+----
+attach:
+
+* [Diapositivas](https://drive.google.com/file/d/1RuamS46QNQggeiZdVfGk0dbMbvn6bxUn/view?usp=sharing)
+* [Recursos](https://drive.google.com/file/d/1roE-5BppgmpcAOOSZaxAve1bCBHQ70R1/view?usp=sharing)
+---
+youtube: XUiIGJNdqlo

--- a/content/eventos/2020-11-19-como-escalar-tu-infraestructura/contents.lr
+++ b/content/eventos/2020-11-19-como-escalar-tu-infraestructura/contents.lr
@@ -4,14 +4,25 @@ date_start: 2020-11-19 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/274509546/
 ---
-information: <p>Via transmisión en Youtube</p> <p>Charla:**¿Cómo escalar tu infraestructura?**</p> <p>Conocer un ciclo lineal de mejora de una arquitectura, desde un aspecto básico, hasta avanzado. Con el objetivo de poder soportar cargar de trabajo en numero de las decenas hasta millones de usuarios, asimismo, teniendo como principio él generar valor para dichos usuarios.</p> <p>Ponente: Jesus David Diaz Diaz</p> <p>Soy estudiante de ingeniería de sistemas con 3 años de experiencia en el desarrolla de software. Apasionado por la tecnología y la ingeniería de software. Actualmente trabajo para Maestrik, como software developer. Con gran énfasis devops.</p> <p>-----</p> <p>Adicionales:</p> <p>1. El evento es gratuito.<br/>2. La charla será en español<br/>3. Transmitiremos la charla por el canal del YouTube de Python Colombia</p> 
+information: 
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/9/e/b/a/600_493480634.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
 title: ¿Cómo escalar tu infraestructura?
 ----
-attach: <a href="https://slides.com/jesusdaviddiaz/deck/fullscreen">Diapositivas</a> /
-<a href="https://youtu.be/jXjchEAOhgA">Video Youtube</a>
+details: Conocer un ciclo lineal de mejora de una arquitectura, desde un aspecto básico, hasta avanzado. Con el objetivo de poder soportar cargar de trabajo en numero de las decenas hasta millones de usuarios, asimismo, teniendo como principio él generar valor para dichos usuarios.
+----
+speaker: 
+----
+speaker_name: Jesus David Diaz Diaz
+----
+speaker_bio: Soy estudiante de ingeniería de sistemas con 3 años de experiencia en el desarrolla de software. Apasionado por la tecnología y la ingeniería de software. Actualmente trabajo para Maestrik, como software developer. Con gran énfasis devops.
+----
+attach:
+
+[Diaspositivas](https://slides.com/jesusdaviddiaz/deck/fullscreen)
+---
+youtube: jXjchEAOhgA

--- a/content/eventos/2020-12-10-lightning-talks-2020/contents+en.lr
+++ b/content/eventos/2020-12-10-lightning-talks-2020/contents+en.lr
@@ -1,0 +1,113 @@
+information:
+
+In December, we will be holding an event that seeks that many of you can tell us about your ideas related to Python, soft skills or programming in general through lightning talks.
+
+We used the Pecha Kucha methodology, in which each speaker will have the opportunity to make their presentation using the 20x20 format, that is, 20 slides with 20 seconds of explanation for each one.
+
+Find the terms of the event in this link
+<a href="https://pybaq.co/blog/lightning-talks-2020/" class="linkified">https://pybaq.co/blog/lightning-talks-2020/</a>
+---
+attach: [Slides folder](https://drive.google.com/drive/folders/12k-k47aD2YI5FSVf1rbcOrCLAWU4XQrz?usp=sharing)
+---
+talks:
+
+#### talk ####
+title: Docker
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Aliexer mayor
+----
+speaker_bio: 
+----
+attach: [Slides](https://docs.google.com/presentation/d/13_9MA2W7I-xgeQCTt-E_ZCdD8QN5_qM6llADCHCjZ50)
+#### talk ####
+title: Me gradué ¿Ahora qué sigue?....English, my friend
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Gabriel Martinez
+----
+speaker_bio: 
+----
+attach: [Slides](https://docs.google.com/presentation/d/1If3cHak6LBhIM9AWVN2OPydq0SeCqrYo)
+#### talk ####
+title:
+
+Como encontrar mi salario justo utilizando ciencia de datos 
+----
+details: 
+----
+speaker: 
+----
+speaker_name: TheCap
+----
+speaker_bio: 
+----
+attach: [Slides](https://docs.google.com/presentation/d/1UGK6RQsYfuXVao9R7tA7B2tLEP7c5YZwTa9vud4uI5M)
+#### talk ####
+title: Cuando los hilos no alcanzan
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Manuel Alvarado
+----
+speaker_bio: 
+----
+attach: [Slides](https://docs.google.com/presentation/d/16nCAUd0yX70RyzpAcI42ad4MEdXKxsa9bhvcoAEjBzk)
+#### talk ####
+title: 💩scripts para la vida
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Jacobo Gómez
+----
+speaker_bio: 
+----
+attach: [Slides](https://docs.google.com/presentation/d/1Y6CAjZfotPjy3f8fXhf-nK5ojYMpiOtjICL579gLA6E)
+#### talk ####
+title: Introducción a la simulación
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Tony Yu
+----
+speaker_bio: [Slides](https://drive.google.com/file/d/1ENbvJuLAXzfyyF1Vn6jmz6fitwo5Y6Va)
+----
+attach: 
+#### talk ####
+title:
+
+Acerca de automatización 
+----
+details: 
+----
+speaker: sergio-orozco
+----
+speaker_name: 
+----
+speaker_bio: 
+----
+attach: [Slides](https://docs.google.com/presentation/d/1MkDby8hS4de9Pi_LNV7QxQiBb6F6NdlM)
+#### talk ####
+title: Testing con python
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Héctor Vega
+----
+speaker_bio: 
+----
+attach: [Slides](https://docs.google.com/presentation/d/14I0RGgrTg0AUTRv25FniTpS6vvarpUqF)

--- a/content/eventos/2020-12-10-lightning-talks-2020/contents.lr
+++ b/content/eventos/2020-12-10-lightning-talks-2020/contents.lr
@@ -119,3 +119,5 @@ speaker_bio:
 attach: [Diaspositivas](https://docs.google.com/presentation/d/14I0RGgrTg0AUTRv25FniTpS6vvarpUqF)
 ---
 attach: [Carpeta de Diaspositivas](https://drive.google.com/drive/folders/12k-k47aD2YI5FSVf1rbcOrCLAWU4XQrz?usp=sharing)
+---
+youtube: 8wAWzRrLF8A

--- a/content/eventos/2020-12-10-lightning-talks-2020/contents.lr
+++ b/content/eventos/2020-12-10-lightning-talks-2020/contents.lr
@@ -4,13 +4,118 @@ date_start: 2020-12-10 19:30
 ---
 link: https://www.meetup.com/pythonbaq/events/274189123/
 ---
-information: <p>[Spanish]</p> <p>En el mes de Diciembre, estaremos realizando un evento que busca que varios de ustedes puedan contarnos acerca de sus ideas relacionadas con Python, habilidades blandas o programación en general a través de charlas relámpago.</p> <p>Utilizaremos la metodología Pecha Kucha, en la cual cada ponente tendrá la oportunidad de hacer su presentación usando el formato 20x20, es decir, 20 diapositivas con 20 segs de explicación por cada una.</p> <p>Encuentra los términos de la convocatoria y como aplicar en este enlace:<br/><a href="https://pybaq.co/blog/lightning-talks-2020/" class="linkified">https://pybaq.co/blog/lightning-talks-2020/</a></p> <p>[English]</p> <p>In December, we will be holding an event that seeks that many of you can tell us about your ideas related to Python, soft skills or programming in general through lightning talks.</p> <p>We will use the Pecha Kucha methodology, in which each speaker will have the opportunity to make their presentation using the 20x20 format, that is, 20 slides with 20 seconds of explanation for each one.</p> <p>Find the terms of the event and how to apply in this link:<br/><a href="https://pybaq.co/blog/lightning-talks-2020/" class="linkified">https://pybaq.co/blog/lightning-talks-2020/</a></p> 
+information:
+
+En el mes de Diciembre, hicimos un evento que buscaba que varios de ustedes puedan contarnos acerca de sus ideas relacionadas con Python, habilidades blandas o programación en general a través de charlas relámpago.
+
+Utilizamos la metodología Pecha Kucha, en la cual cada ponente tendrá la oportunidad de hacer su presentación usando el formato 20x20, es decir, 20 diapositivas con 20 segs de explicación por cada una.
+
+Encuentra los términos de la convocatoria y como aplicar en este enlace:
+<a href="https://pybaq.co/blog/lightning-talks-2020/" class="linkified">https://pybaq.co/blog/lightning-talks-2020/</a>
 ---
 featured_photo: https://secure.meetupstatic.com/photos/event/5/e/c/b/600_493824267.jpeg
 ---
-talks: 
+talks:
 
 #### talk ####
-title: Lightning Talks 2020
+title: Docker
 ----
-attach: <a href="https://drive.google.com/drive/folders/12k-k47aD2YI5FSVf1rbcOrCLAWU4XQrz?usp=sharing">Diapositivas</a> / <a href="https://youtu.be/8wAWzRrLF8A">Video Youtube</a>
+details: 
+----
+speaker: 
+----
+speaker_name: Aliexer mayor
+----
+speaker_bio: 
+----
+attach: [Diaspositivas](https://docs.google.com/presentation/d/13_9MA2W7I-xgeQCTt-E_ZCdD8QN5_qM6llADCHCjZ50)
+#### talk ####
+title: Me gradué ¿Ahora qué sigue?....English, my friend
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Gabriel Martinez
+----
+speaker_bio: 
+----
+attach: [Diaspositivas](https://docs.google.com/presentation/d/1If3cHak6LBhIM9AWVN2OPydq0SeCqrYo)
+#### talk ####
+title:
+
+Como encontrar mi salario justo utilizando ciencia de datos 
+----
+details: 
+----
+speaker: 
+----
+speaker_name: TheCap
+----
+speaker_bio: 
+----
+attach: [Diaspositivas](https://docs.google.com/presentation/d/1UGK6RQsYfuXVao9R7tA7B2tLEP7c5YZwTa9vud4uI5M)
+#### talk ####
+title: Cuando los hilos no alcanzan
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Manuel Alvarado
+----
+speaker_bio: 
+----
+attach: [Diaspositivas](https://docs.google.com/presentation/d/16nCAUd0yX70RyzpAcI42ad4MEdXKxsa9bhvcoAEjBzk)
+#### talk ####
+title: 💩scripts para la vida
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Jacobo Gómez
+----
+speaker_bio: 
+----
+attach: [Diaspositivas](https://docs.google.com/presentation/d/1Y6CAjZfotPjy3f8fXhf-nK5ojYMpiOtjICL579gLA6E)
+#### talk ####
+title: Introducción a la simulación
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Tony Yu
+----
+speaker_bio: [Diaspositivas](https://drive.google.com/file/d/1ENbvJuLAXzfyyF1Vn6jmz6fitwo5Y6Va)
+----
+attach: 
+#### talk ####
+title:
+
+Acerca de automatización 
+----
+details: 
+----
+speaker: sergio-orozco
+----
+speaker_name: 
+----
+speaker_bio: 
+----
+attach: [Diaspositivas](https://docs.google.com/presentation/d/1MkDby8hS4de9Pi_LNV7QxQiBb6F6NdlM)
+#### talk ####
+title: Testing con python
+----
+details: 
+----
+speaker: 
+----
+speaker_name: Héctor Vega
+----
+speaker_bio: 
+----
+attach: [Diaspositivas](https://docs.google.com/presentation/d/14I0RGgrTg0AUTRv25FniTpS6vvarpUqF)
+---
+attach: [Carpeta de Diaspositivas](https://drive.google.com/drive/folders/12k-k47aD2YI5FSVf1rbcOrCLAWU4XQrz?usp=sharing)


### PR DESCRIPTION
# Pull request

No cierra issues, hace parte del milestone de migrar todos los eventos al nuevo esquema

## Observaciones

No pude colocar los videos de facebook en la cabecera por que ya ese espacio lo tenemos reservado para youtube, creo que seria bueno crear una nueva tarea para investigar como podemos embeber videos de facebook asi como hacemos con los de youtube

Tuve en cuenta que oswaldo tiene 2 eventos durante este año, asi que por eso necesitaba el merge del pr donde se creó su perfil