### PR TITLE
speaker event tambien retorna la charla

### DIFF
--- a/packages/lektor-speaker-events/lektor_speaker_events.py
+++ b/packages/lektor-speaker-events/lektor_speaker_events.py
@@ -6,8 +6,13 @@ class SpeakerEventsPlugin(Plugin):
     name = 'Speaker Events'
     description = u'Lektor plugin that adds a function to filter events by speaker.'
 
-    def on_setup_env(self):
+    def on_setup_env(self, **extra):
         def speaker_events(eventos, speaker):
-            return [evento for evento in eventos if evento["talks"] and speaker in [talk["speaker"] for talk in evento["talks"].blocks]]
-
+            filtered = []
+            for evento in eventos:
+                if evento["talks"]:
+                    for talk in evento["talks"].blocks:
+                        if speaker in talk["speaker"]:
+                            filtered.append({"event": evento, "talk": talk})
+            return filtered
         self.env.jinja_env.filters["speakerevents"] = speaker_events

--- a/packages/lektor-speaker-events/setup.py
+++ b/packages/lektor-speaker-events/setup.py
@@ -25,7 +25,7 @@ setup(
     packages=find_packages(),
     py_modules=['lektor_speaker_events'],
     # url='[link to your repository]',
-    version='0.1',
+    version='0.2',
     classifiers=[
         'Framework :: Lektor',
         'Environment :: Plugins',

--- a/templates/nosotros-miembro.html
+++ b/templates/nosotros-miembro.html
@@ -74,7 +74,13 @@
       <div class="events-user row"></div>
         {% for event in eventos %}
           <div>
-            <a href="{{event|url}}">{{event.title}}</a>
+            <a href="{{event.event|url}}">
+              {% if event.talk.title %}
+                {{event.talk.title}}
+              {% else %}
+                {{event.event.title}}
+              {% endif %}  
+            </a>
           </div>
         {% endfor %}
       </div>


### PR DESCRIPTION
# Pull request

Closes #556 

## Observaciones

Se cambio el plugin para que tambien retorne información de la charla, como se requiere mantener el evento se sigue usando
En el listado de charlas dentro del perfil del miembro solo se muestra el nombre de la charla. Se permite la navegación hacia el evento
Si hay un evento donde la charla no tenga titulo, se usara el titulo del evento, un ejemplo de este escenario es el conversatorio de junior a senior
Se adiciono  **extra al plugin por que estaba exigiendolo y para eliminar el warning decidi hacer el cambio

Anexo las charlas dentro de mi perfil
![image](https://github.com/user-attachments/assets/6d94ebf5-5142-445d-b499-05715219cf44)

